### PR TITLE
feat(text_manager): implement SWMateAnalyzer caching system

### DIFF
--- a/cli/core/context_manager.py
+++ b/cli/core/context_manager.py
@@ -1,4 +1,13 @@
 import importlib
+import datetime
+import tempfile
+import os
+import json
+from io import StringIO
+from rich.console import Console
+
+from .analyzer import CoeAnalyzer
+from ..ui.interactive import analysis_keywords
 from .debug_manager import DebugManager
 
 class PromptBuilder:
@@ -8,6 +17,8 @@ class PromptBuilder:
         # RepoMap 캐싱용 저장소
         self._repo_map_cache = {}
         self._cache_key = None
+        # SWMateAnalyzer 캐싱용 저장소
+        self._swmate_analysis_cache = {}
 
     def _load_prompt_class(self):
         try:
@@ -18,6 +29,13 @@ class PromptBuilder:
             return prompt_class()
         except (ImportError, AttributeError) as e:
             raise ValueError(f"Invalid task name '{self.task}'. Could not load prompts.") from e
+
+    def set_task(self, task: str):
+        """캐시를 유지하면서 task 모드 변경"""
+        if self.task != task:
+            self.task = task
+            self.prompts = self._load_prompt_class()
+            DebugManager.info(f"PromptBuilder task 변경됨: {task}")
 
     def build(self, user_input: str, file_context: dict, history: list = None, file_manager=None):
         # 입출력 관련 질문인지 검사
@@ -56,6 +74,14 @@ class PromptBuilder:
                     file_str += f"\n\n{detailed_analysis}"
 
                 messages.append({"role": "system", "content": file_str})
+
+        # 4. Add SWMateAnalyzer results if available (for structure analysis requests)
+        swmate_analysis = self._get_relevant_swmate_analysis(user_input, file_context)
+        if swmate_analysis:
+            for file_path, analysis in swmate_analysis.items():
+                analysis_str = f"File Structure Analysis for {file_path}:\n{json.dumps(analysis, ensure_ascii=False, indent=2)}"
+                messages.append({"role": "system", "content": analysis_str})
+                DebugManager.swmate_analyzer(f"SWMateAnalyzer 결과를 프롬프트에 포함: {file_path}")
 
         # 4. Add existing history
         messages.extend(history)
@@ -392,6 +418,118 @@ class PromptBuilder:
         latest_size = len(self._repo_map_cache[latest_key])
 
         return f"✅ 캐시된 레포맵: {cache_count}개, 최신 크기: {latest_size} chars"
+
+    def get_cached_swmate_analysis(self, file_path: str):
+        """캐싱된 SWMateAnalyzer 분석 결과 반환"""
+        if file_path in self._swmate_analysis_cache:
+            cached_data = self._swmate_analysis_cache[file_path]
+            DebugManager.swmate_analyzer(f"✅ 캐시된 SWMateAnalyzer 결과 사용: {file_path}")
+            return cached_data.get('analysis')
+        return None
+
+    def perform_swmate_analysis_on_demand(self, file_path: str, file_content: str, file_manager=None):
+        """요청 시에만 SWMateAnalyzer 실행하고 캐싱"""
+        try:
+            DebugManager.swmate_analyzer(f"SWMateAnalyzer 실행 시작: {file_path}")
+            # CoeAnalyzer 인스턴스 생성
+            analyzer = CoeAnalyzer()
+            # 임시 파일 생성하여 분석 (기존 _get_detailed_analysis 로직 참고)
+            with tempfile.NamedTemporaryFile(mode='w', suffix=os.path.splitext(file_path)[1], delete=False, encoding='utf-8') as tmp_file:
+                tmp_file.write(file_content)
+                tmp_path = tmp_file.name
+
+            try:
+                # 화면 출력 없이 분석 수행
+                original_console = analyzer.console
+
+
+                # 출력을 StringIO로 리다이렉트
+                quiet_console = Console(file=StringIO(), stderr=False)
+                analyzer.console = quiet_console
+
+                # LLM 분석 수행 (기본 분석 + LLM 심화 분석)
+                results = analyzer.analyze_files([tmp_path], use_llm=True)
+
+                # 원래 console 복원
+                analyzer.console = original_console
+
+                if results and 'files' in results and tmp_path in results['files']:
+                    file_info = results['files'][tmp_path]
+
+                    # 캐시에 저장
+                    cache_data = {
+                        'timestamp': datetime.datetime.now().isoformat(),
+                        'analysis': {
+                            'basic_analysis': file_info.get('basic_analysis', {}),
+                            'llm_analysis': file_info.get('llm_analysis', {}),
+                            'file_type': file_info.get('file_type', 'unknown')
+                        }
+                    }
+
+                    self._swmate_analysis_cache[file_path] = cache_data
+
+                    DebugManager.swmate_analyzer(f"✅ SWMateAnalyzer 분석 완료 및 캐시 저장: {file_path}")
+                    return cache_data['analysis']
+                else:
+                    DebugManager.swmate_analyzer(f"❌ SWMateAnalyzer 분석 결과 없음: {file_path}")
+                    return None
+
+            finally:
+                # 임시 파일 삭제
+                os.unlink(tmp_path)
+
+        except Exception as e:
+            DebugManager.error(f"SWMateAnalyzer 분석 실패 ({file_path}): {e}")
+            return None
+
+    def get_swmate_cache_status(self):
+        """SWMateAnalyzer 캐시 상태 확인"""
+        if not self._swmate_analysis_cache:
+            return "❌ 캐시된 SWMateAnalyzer 분석 결과 없음"
+
+        cache_count = len(self._swmate_analysis_cache)
+        cached_files = list(self._swmate_analysis_cache.keys())
+
+        status = f"✅ 캐시된 SWMateAnalyzer 분석: {cache_count}개 파일\n"
+        for file_path in cached_files:
+            filename = os.path.basename(file_path)
+            timestamp = self._swmate_analysis_cache[file_path].get('timestamp', 'unknown')
+            status += f"  • {filename} ({timestamp})\n"
+
+        return status.strip()
+
+    def _get_relevant_swmate_analysis(self, user_input: str, file_context: dict):
+        """사용자 입력과 파일 컨텍스트를 기반으로 관련된 SWMateAnalyzer 분석 결과 반환"""
+        # 구조 분석 키워드 감지
+   
+        has_analysis_request = any(keyword in user_input.lower() for keyword in analysis_keywords)
+
+        if not has_analysis_request:
+            return {}
+
+        DebugManager.swmate_analyzer(f"구조 분석 키워드 감지됨: {user_input[:50]}...")
+
+        # 분석 요청이 감지된 경우, 컨텍스트의 모든 파일에 대해 SWMateAnalyzer 결과 확인
+        relevant_analysis = {}
+
+        if file_context:
+            for file_path, content in file_context.items():
+                # 캐시된 결과 확인
+                cached_analysis = self.get_cached_swmate_analysis(file_path)
+
+                if cached_analysis:
+                    relevant_analysis[file_path] = cached_analysis
+                else:
+                    # 캐시에 없으면 새로 분석 수행
+                    DebugManager.swmate_analyzer(f"SWMateAnalyzer 새 분석 수행: {file_path}")
+                    new_analysis = self.perform_swmate_analysis_on_demand(file_path, content, None)
+                    if new_analysis:
+                        relevant_analysis[file_path] = new_analysis
+
+        if relevant_analysis:
+            DebugManager.swmate_analyzer(f"SWMateAnalyzer 분석 결과 {len(relevant_analysis)}개 파일에 대해 프롬프트에 포함")
+
+        return relevant_analysis
 
     def _extract_mentioned_files(self, text: str):
         """텍스트에서 언급된 파일명 추출"""

--- a/cli/core/debug_manager.py
+++ b/cli/core/debug_manager.py
@@ -11,6 +11,7 @@ class DebugManager:
 
     색깔 코드:
     - RepoMap: cyan
+    - SWMateAnalyzer: bright_yellow
     - FileAnalysis: yellow
     - Context: blue
     - Error: red
@@ -42,6 +43,13 @@ class DebugManager:
         if cls._debug_enabled:
             console = cls._get_console()
             console.print(f"[cyan dim][RepoMap DEBUG][/cyan dim] [dim]{message}[/dim]")
+
+    @classmethod
+    def swmate_analyzer(cls, message: str):
+        """SWMateAnalyzer 관련 디버그 출력 (bright_yellow)"""
+        if cls._debug_enabled:
+            console = cls._get_console()
+            console.print(f"[bright_yellow dim][SWMateAnalyzer DEBUG][/bright_yellow dim] [dim]{message}[/dim]")
 
     @classmethod
     def file_analysis(cls, message: str):

--- a/cli/main.py
+++ b/cli/main.py
@@ -64,7 +64,9 @@ def main():
     edit_strategy = 'whole'  # 기본 편집 전략
     last_edit_response = None  # 마지막 edit 응답 저장
     last_user_request = None  # 마지막 사용자 요청 저장
-    current_coder = registry.get_coder(edit_strategy, file_editor)  # 현재 코더
+    current_coder = registry.get_coder(edit_strategy, file_editor)  # 현재 코더 
+    # 영구 PromptBuilder 인스턴스 (캐시 유지용)
+    prompt_builder = PromptBuilder('ask')
 
     # 웰컴 메시지
     interactive_ui.display_welcome_banner(task)
@@ -82,15 +84,9 @@ def main():
                 continue
 
             elif user_input.strip().lower().startswith('/repo'):
-                # PromptBuilder import를 블록 밖으로 이동
-                from cli.core.context_manager import PromptBuilder
-
                 parts = user_input.strip().split()
                 if len(parts) > 1:
                     target_files = [p.replace('@', '') for p in parts[1:]]
-
-                    # PromptBuilder 인스턴스 생성 (ask용)
-                    prompt_builder = PromptBuilder('ask')
 
                     # 수동으로 레포맵 생성
                     repo_map = prompt_builder.generate_repo_map_manually(target_files, file_manager)
@@ -102,11 +98,20 @@ def main():
                         console.print("[red]•  RepoMap 생성에 실패했습니다.[/red]")
                 else:
                     # 상태 확인
-                    prompt_builder = PromptBuilder('ask')
                     status = prompt_builder.get_repo_map_status()
                     console.print(f"[cyan]•  RepoMap 상태: {status}[/cyan]")
                     console.print("[dim]사용법: /repo <파일1> <파일2> ... 또는 /repo (상태 확인)[/dim]")
                 continue
+
+            elif user_input.strip().lower().startswith('/swmate-cache'):
+                # SWMateAnalyzer 캐시 상태 확인
+                parts = user_input.strip().split()
+                if len(parts) == 1 or (len(parts) == 2 and parts[1] == 'status'):
+                    # 캐시 상태 확인
+                    status = prompt_builder.get_swmate_cache_status()
+                    console.print(f"[cyan]•  SWMateAnalyzer 캐시 상태:[/cyan]")
+                    console.print(status)
+                    continue
 
             elif user_input.strip().lower().startswith('/add '):
                 parts = user_input.strip().split()
@@ -450,8 +455,8 @@ def main():
                 # 일반 사용자 입력 - AI에게 전달 (의도 분석 없이 바로 처리)
                 interactive_ui.display_separator()
 
-            # Build the prompt using MCP-integrated PromptBuilder
-            prompt_builder = mcp_integration.create_prompt_builder(task)
+            # Build the prompt using persistent PromptBuilder (캐시 유지)
+            prompt_builder.set_task(task)  # task 모드만 변경 (캐시는 유지)
             messages = prompt_builder.build(user_input, file_manager.files, chat_history, file_manager)
 
             # 입출력 관련 질문인지 확인하고 JSON 강제 모드 사용

--- a/cli/ui/interactive.py
+++ b/cli/ui/interactive.py
@@ -2,10 +2,14 @@
 Interactive UI module - Handles user interactions and mode switching
 """
 
+from click import File
 from rich.console import Console
 from typing import Dict, List, Any
 import re
 
+from actions.file_manager import FileManager
+
+analysis_keywords = ['구조 분석', '분석해줘', '어떤 파일', '파일 구조', '코드 분석']
 
 class InteractiveUI:
     """Handles interactive UI elements and mode switching"""
@@ -107,6 +111,7 @@ class InteractiveUI:
 [yellow]/info[/yellow] <file> - 이미 추가된 파일의 상세 분석 정보 다시 보기
 [yellow]/repo[/yellow] <file1> <file2> ... - 지정한 파일들로 Repository Map 생성 (질문 시 자동 포함)
 [yellow]/repo[/yellow] - 현재 Repository Map 상태 확인
+[yellow]/swmate-cache status[/yellow] - SWMateAnalyzer 캐시 상태 확인
 [yellow]/clear[/yellow] - 대화 기록 초기화
 
 
@@ -174,6 +179,7 @@ class InteractiveUI:
                 f"[red]• 알 수 없는 명령어: '{command_part}'[/red]\n\n"
                 f"[white]• 사용 가능한 명령어:[/white]\n"
                 f"[dim white]• 파일 관리: /add, /files, /tree, /analyze, /info, /clear[/dim white]\n"
+                f"[dim white]• 분석 도구: /repo, /swmate-cache[/dim white]\n"
                 f"[dim white]• 모드 전환: /ask, /edit[/dim white]\n"
                 f"[dim white]• 편집 기능: /preview, /apply, /history, /rollback, /debug[/dim white]\n"
                 f"[dim white]• 세션 관리: /session, /session-reset[/dim white]\n"
@@ -217,7 +223,6 @@ class InteractiveUI:
             r'@([a-zA-Z0-9_/\\.-]+)',                # @로 시작하는 파일 참조
         ]
         
-        analysis_keywords = ['분석', '분석해', '봐줘', 'analyze', '설명해', '알려줘']
         
         detected_files = []
         for pattern in file_patterns:

--- a/tests/test_with_fixtures.py
+++ b/tests/test_with_fixtures.py
@@ -295,6 +295,64 @@ def test_edit_functionality_with_fixtures():
     else:
         console.print(f"[red]❌ 원본 파일이 없습니다: {original_file}[/red]")
 
+def test_swmate_cache_status(file_manager:FileManager):
+    """7. SWMateAnalyzer 캐시 상태 확인 테스트 (실제 CLI 워크플로우 재현)"""
+    from cli.core.context_manager import PromptBuilder
+
+    prompt_builder = PromptBuilder('ask')
+    # 초기 캐시 상태 확인
+    initial_status = prompt_builder.get_swmate_cache_status()
+    assert "없음" in initial_status
+
+    sql_file = './tests/fixtures/zord_svc_prod_grp_s0001.sql'
+    if sql_file not in file_manager.files:
+        console.print(f"[yellow]파일 추가: {sql_file}[/yellow]")
+        file_manager.add([sql_file])
+    
+    file_content = file_manager.files[sql_file]
+    file_context = {sql_file: file_content}
+
+    # 첫 번째 분석 요청 - LLM 호출하고 캐시 생성
+    user_input_1 = '이 SQL 파일의 구조 분석해줘'  # '구조 분석' 키워드 포함
+    
+    try:
+        relevant_1 = prompt_builder._get_relevant_swmate_analysis(user_input_1, file_context)
+        
+        if relevant_1:
+            console.print(f"[green]✅ 분석 완료, 캐시에 저장됨: {len(relevant_1)}개 파일[/green]")
+        else:
+            console.print(f"[yellow]⚠️  LLM 호출 실패 (서버 연결 오류), 캐시 테스트 건너뜀[/yellow]")
+            console.print("[dim]참고: 실제 CLI에서는 LLM 서버가 필요합니다[/dim]")
+            return
+            
+    except Exception as e:
+        console.print(f"[yellow]⚠️  LLM 호출 중 오류: {e}[/yellow]")
+        console.print("[dim]참고: 실제 CLI에서는 LLM 서버가 필요합니다[/dim]")
+        return
+
+    # 캐시 상태 확인 - 캐시된 파일이 표시되어야 함 (/swmate-cache status와 동일)
+    status_after_analysis = prompt_builder.get_swmate_cache_status()
+    console.print(f"\n[dim]3) 분석 후 캐시 상태:[/dim]\n{status_after_analysis}")
+    assert os.path.basename(sql_file) in status_after_analysis
+    assert "✅" in status_after_analysis
+
+    # 캐시에서 직접 분석 결과 조회
+    cached = prompt_builder.get_cached_swmate_analysis(sql_file)
+    console.print(f"[green]✅ 캐시에서 분석 결과 조회 성공[/green]")
+    assert isinstance(cached, dict)
+    assert 'basic_analysis' in cached or 'llm_analysis' in cached
+
+    # 두 번째 분석 요청 - 캐시 사용 (새로운 LLM 호출 없음)
+    console.print(f"\n[dim]4) 두 번째 분석 요청 (캐시 사용 확인)...[/dim]")
+    user_input_2 = '분석해줘'  # 한국어 키워드
+    relevant_2 = prompt_builder._get_relevant_swmate_analysis(user_input_2, file_context)
+    
+    console.print(f"[green]✅ 캐시된 결과 사용됨 (LLM 호출 없음)[/green]")
+    assert sql_file in relevant_2
+    assert relevant_2[sql_file] == cached  # 캐시에서 가져온 동일한 객체여야 함
+
+    console.print("\n[bold green]✅ SWMateAnalyzer 캐시 상태 테스트 완료 (실제 워크플로우)[/bold green]")
+
 if __name__ == "__main__":
     console.print("[bold green]🚀 Fixtures 파일로 Swing CLI 기능 테스트 시작[/bold green]")
 
@@ -315,5 +373,8 @@ if __name__ == "__main__":
 
     # 6. Edit 기능 테스트
     test_edit_functionality_with_fixtures()
+
+    # 7. SWMateAnalyzer 캐시 상태 확인 테스트
+    test_swmate_cache_status(file_manager)
 
     console.print("\n[bold green]✅ 모든 Fixtures 테스트 완료![/bold green]")


### PR DESCRIPTION
Related to: #[12](https://github.com/mjkim1019/coe-cli/issues/12)

Summary of Changes

1. Added `/swmate-cache status` command to allow users to check the current status of the cache.
2. Refactored `PromptBuilder("ask")` to use a global prompt instance instead of creating a new prompt for each command, enabling cache sharing across commands.
3. Updated test files to cover the new cache functionality.
4. Implemented DEBUG-level logging for `swmate-cache` for easier troubleshooting and monitoring.

How to review

Please refer to the video below for step-by-step testing instructions.
[Implement-SwmateAnalyzer-cache-demo.webm](https://github.com/user-attachments/assets/db10df38-bb6a-4f82-ae88-526069bed890)


