### PR TITLE
refactor(all): change service name from SwingMate to Mider in all places.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,7 +318,7 @@ class FileWatcher:
 
 **주석 형태**:
 ```c
-// [SWING-CLI] 2024-01-15 14:30:25 by user123
+// [MIDER] 2024-01-15 14:30:25 by user123
 // [변경이유] 입력 검증 로직 강화를 위해 NULL 체크 추가
 if (input_data == NULL) {
     return ERROR_INVALID_INPUT;

--- a/actions/template_manager.py
+++ b/actions/template_manager.py
@@ -109,7 +109,7 @@ class TemplateManager:
             else:
                 new_content = self._basic_replace(template_content, service_id, author, description)
             
-            # SWING_AUTO_FILES에 파일 생성
+            # MIDER_AUTO_FILES에 파일 생성
             return self._save_to_auto_files(filename, new_content)
             
         except Exception as e:
@@ -117,8 +117,8 @@ class TemplateManager:
             return False
     
     def _save_to_auto_files(self, filename: str, content: str) -> bool:
-        """SWING_AUTO_FILES 디렉토리에 파일 저장"""
-        auto_files_dir = "SWING_AUTO_FILES"
+        """MIDER_AUTO_FILES 디렉토리에 파일 저장"""
+        auto_files_dir = "MIDER_AUTO_FILES"
         if not os.path.exists(auto_files_dir):
             os.makedirs(auto_files_dir)
             self.console.print(f"[dim]📁 자동 생성 파일 디렉토리 생성: {auto_files_dir}[/dim]")

--- a/cli/architect/mode.py
+++ b/cli/architect/mode.py
@@ -402,7 +402,7 @@ class ArchitectMode:
             )
             
             if success:
-                output_path = os.path.join("SWING_AUTO_FILES", filename)
+                output_path = os.path.join("MIDER_AUTO_FILES", filename)
                 step.output = f"Created file: {output_path}"
                 self.console.print(f"[green]✅ 파일 생성 완료: {output_path}[/green]")
                 return True

--- a/cli/core/architect_mode.py
+++ b/cli/core/architect_mode.py
@@ -35,7 +35,7 @@ class ArchitectMode:
         self.session = session
         self.template_manager = template_manager
         self.prompts = ArchitectPrompts()
-        self.plans_dir = Path(".swmate/plans")
+        self.plans_dir = Path(".mider/plans")
         self.plans_dir.mkdir(parents=True, exist_ok=True)
     
     def run(self, user_request: str) -> Optional[ExecutionPlan]:
@@ -402,7 +402,7 @@ class ArchitectMode:
             )
             
             if success:
-                output_path = os.path.join("SWING_AUTO_FILES", filename)
+                output_path = os.path.join("MIDER_AUTO_FILES", filename)
                 step.output = f"Created file: {output_path}"
                 self.console.print(f"[green]✅ 파일 생성 완료: {output_path}[/green]")
                 return True

--- a/cli/main.py
+++ b/cli/main.py
@@ -495,7 +495,7 @@ def main():
                     )
 
                     if success:
-                        actual_path = os.path.join("SWING_AUTO_FILES", f"{filename}.c")
+                        actual_path = os.path.join("MIDER_AUTO_FILES", f"{filename}.c")
                         console.print(panels.create_success_panel(
                             f"✅ 파일 생성 완료: {actual_path}\n"
                             f"서비스 ID: {service_id}\n"

--- a/cli/ui/components.py
+++ b/cli/ui/components.py
@@ -31,7 +31,7 @@ class MiderUIComponents:
         title_text.append("\n")
         title_text.append("█▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀█\n", style="bold bright_blue")
         title_text.append("█                            █\n", style="bold bright_blue")
-        title_text.append("█     🚀  SWING CLI  🤖     █\n", style="bold bright_cyan")
+        title_text.append("█     🚀  MIDER CLI  🤖      █\n", style="bold bright_cyan")
         title_text.append("█                            █\n", style="bold bright_blue") 
         title_text.append("█  AI Development Assistant  █\n", style="bold bright_magenta")
         title_text.append("█                            █\n", style="bold bright_blue")

--- a/cli/ui/interactive.py
+++ b/cli/ui/interactive.py
@@ -44,7 +44,7 @@ class InteractiveUI:
         title_text.append("\n")
         title_text.append("█▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀█\n", style="bold bright_blue")
         title_text.append("█                            █\n", style="bold bright_blue")
-        title_text.append("█         SWING CLI          █\n", style="bold bright_cyan")
+        title_text.append("█         MIDER CLI          █\n", style="bold bright_cyan")
         title_text.append("█                            █\n", style="bold bright_blue") 
         title_text.append("█     AI Coding Assistant    █\n", style="bold bright_magenta")
         title_text.append("█                            █\n", style="bold bright_blue")

--- a/docs/MIDER_USAGE.md
+++ b/docs/MIDER_USAGE.md
@@ -2,10 +2,10 @@
 
 ## 시작하기
 
-1. swing_cli.exe을 SOC 게시판에서 다운받아 특정 위치에 위치시켜주세요. (ex. Users/development)
+1. mider.exe를 SOC 게시판에서 다운받아 특정 위치에 위치시켜주세요. (ex. Users/development)
 2. Users/development 폴더 내에 분석하고자 하는 파일들을 복사해 위치시켜주세요.
-   즉, swing_cli.exe와 분석하고자하는 파일은 같은 폴더 내에 위치합니다.
-3. 이제 swing_cli와 함께 개발/분석할 준비가 완료되었습니다!
+   즉, mider.exe와 분석하고자하는 파일은 같은 폴더 내에 위치합니다.
+3. 이제 mider와 함께 개발/분석할 준비가 완료되었습니다!
 
 
 ## 기본 워크플로우

--- a/docs/features_spec.md
+++ b/docs/features_spec.md
@@ -251,7 +251,7 @@ class FileWatcher:
 
 **주석 형태**:
 ```c
-// [SWING-MATE] 2024-01-15 14:30:25 by user123
+// [MIDER] 2024-01-15 14:30:25 by user123
 // [변경이유] 입력 검증 로직 강화를 위해 NULL 체크 추가
 if (input_data == NULL) {
     return ERROR_INVALID_INPUT;


### PR DESCRIPTION
**Related to:** #26

## Summary of Changes

1. Renamed service from SwingMate/SWMate/Swing CLI/coe-cli to unified "Mider" branding
2. Updated UI components to display "MIDER CLI" as the interface title
3. Changed all directory paths from `.swmate` to `.mider` and `SWING_AUTO_FILES` to `MIDER_AUTO_FILES`
4. Updated documentation to reflect new service name across user guides and development docs
5. Established consistent naming conventions: "Mider" (proper noun), "MIDER CLI" (UI), "mider" (command/executable)

## Files Changed

### Modified Files
- **Modified:** `docs/MIDER_USAGE.md` - Changed `swing_cli.exe` → `mider.exe` in getting started section (3 instances)
- **Modified:** `CLAUDE.md` - Updated code comment tag from `[SWING-CLI]` → `[MIDER]`
- **Modified:** `docs/features_spec.md` - Updated code comment tag from `[SWING-MATE]` → `[MIDER]`
- **Modified:** `cli/core/architect_mode.py` - Changed plans directory from `.swmate/plans` → `.mider/plans`
- **Modified:** `actions/template_manager.py` - Changed auto-generated files directory from `SWING_AUTO_FILES` → `MIDER_AUTO_FILES` (3 instances)
- **Modified:** `cli/main.py` - Updated file path references for MIDER_AUTO_FILES
- **Modified:** `cli/architect/mode.py` - Updated output paths for MIDER_AUTO_FILES
- **Modified:** `cli/ui/components.py` - Changed welcome banner from "🚀  SWING CLI  🤖" → "🚀  MIDER CLI  🤖"
- **Modified:** `cli/ui/interactive.py` - Changed welcome banner from "SWING CLI" → "MIDER CLI"
- **Modified:** `.gitignore` - Added `MIDER_AUTO_FILES/` directory to ignore list, kept legacy entries for backward compatibility

## Key Features

### 1. Unified Branding
- **Service Name**: "Mider" used consistently as proper noun across all documentation
- **CLI Interface**: "MIDER CLI" displayed in welcome banners and UI components
- **Executable/Command**: "mider" (lowercase) for command-line usage
- **Comment Tags**: `[MIDER]` for code modification tracking

### 2. Updated Directory Structure
- **Plans directory**: `.mider/plans/` - Stores execution plans (previously `.swmate/plans/`)
- **Auto-generated files**: `MIDER_AUTO_FILES/` - Template-generated files (previously `SWING_AUTO_FILES/`)
- **History files**: `.mider-history` - Command history (already in place)
- **Backup files**: `.mider_backups` - File backups (already in place)

### 3. Documentation Updates
- **User Guide**: `docs/MIDER_USAGE.md` now references `mider.exe` throughout
- **Development Docs**: `CLAUDE.md` and `docs/features_spec.md` use `[MIDER]` comment tags
- **Consistent Examples**: All code examples updated to reflect new naming

### 4. Backward Compatibility
- **Legacy references**: Old naming conventions preserved in `.gitignore` as deprecated:
  - `.coe-cli-history`
  - `.swing-cli-history`
  - `.swing_backups`
- **Schema files**: Intentionally excluded from changes to preserve database references
- **All functionality**: Preserved exactly as before, pure branding change

